### PR TITLE
Add support for copying stdin

### DIFF
--- a/cat.js
+++ b/cat.js
@@ -1,11 +1,18 @@
 var fs = require('fs');
+var readFileSync = require('fs-file-sync-fd').readFileSync;
+
+var STDIN_FILENO = 0;
 
 function cat(result, file) {
   var stdout = '';
   var stderr = '';
 
   try {
-    stdout = result.stdout + fs.readFileSync(file, 'utf8');
+    if (file === '-') {
+      stdout = result.stdout + readFileSync(STDIN_FILENO, 'utf8');
+    } else {
+      stdout = result.stdout + fs.readFileSync(file, 'utf8');
+    }
     stderr = result.stderr;
   } catch (e) {
     stdout = result.stdout;

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 var cat = require('./cat');
 
-var results = cat(process.argv.slice(2));
+var results = cat(process.argv.length > 2 ? process.argv.slice(2) : ['-']);
 
 if (results.stderr.length) {
   process.stderr.write(results.stderr);

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "pre-commit": [
     "lint",
     "test"
-  ]
+  ],
+  "dependencies": {
+    "fs-file-sync-fd": "^0.1.0"
+  }
 }

--- a/test/functional.js
+++ b/test/functional.js
@@ -59,3 +59,39 @@ test('cat non-existing file and a valid file', function (t) {
       t.end();
     });
 });
+
+
+test('cat stdin by name', function (t) {
+  exec2('node cli - < package.json',
+    'cat - < package.json',
+    function (error, stdout, stderr) {
+      t.equal(error[0], error[1], 'same error');
+      t.equal(stdout[0], stdout[1], 'same stdout');
+      t.equal(stderr[0], stderr[1], 'same stderr');
+      t.end();
+    });
+});
+
+
+test('cat file stdin file', function (t) {
+  exec2('node cli package.json - README.md < package.json',
+    'cat package.json - README.md < package.json',
+    function (error, stdout, stderr) {
+      t.equal(error[0], error[1], 'same error');
+      t.equal(stdout[0], stdout[1], 'same stdout');
+      t.equal(stderr[0], stderr[1], 'same stderr');
+      t.end();
+    });
+});
+
+
+test('cat stdin twice', function (t) {
+  exec2('node cli - - < package.json',
+    'cat - - < package.json',
+    function (error, stdout, stderr) {
+      t.equal(error[0], error[1], 'same error');
+      t.equal(stdout[0], stdout[1], 'same stdout');
+      t.equal(stderr[0], stderr[1], 'same stderr');
+      t.end();
+    });
+});

--- a/test/functional.js
+++ b/test/functional.js
@@ -61,6 +61,18 @@ test('cat non-existing file and a valid file', function (t) {
 });
 
 
+test('cat stdin by default', function (t) {
+  exec2('node cli < package.json',
+    'cat < package.json',
+    function (error, stdout, stderr) {
+      t.equal(error[0], error[1], 'same error');
+      t.equal(stdout[0], stdout[1], 'same stdout');
+      t.equal(stderr[0], stderr[1], 'same stderr');
+      t.end();
+    });
+});
+
+
 test('cat stdin by name', function (t) {
   exec2('node cli - < package.json',
     'cat - < package.json',


### PR DESCRIPTION
This PR adds support for concatenating `stdin`, both in place of the file name `-` and when no file arguments are provided, as specified by POSIX/SUSv3.

It uses the `fs-file-sync-fd` module that I created specifically for this purpose, which contains a copy of `readFileSync` from nodejs/node@08039628 which introduced support for reading from an open file descriptor.  If you are concerned about introducing a dependency, the code could easily be copied into this module.

Although the code is covered by the functional tests, it is not covered by the unit tests.  This reduced the coverage numbers a bit.  Without access to the `dup2(2)` function, I didn't see a good way to test without forking.  Let me know how you'd like to handle this, if at all.

Thanks,
Kevin
